### PR TITLE
Remove psr/log to allow laravel 9/10 compatibility

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,6 @@
   ],
   "require": {
     "php": ">=7.0",
-    "psr/log": "^1.0",
     "juhniorsantos/record-processor": "^0.11|^0.12",
     "illuminate/support": "^5.4|^6.0|^7.0|^8.0|^9.0|^10.0",
     "illuminate/contracts": "^5.4|^6.0|^7.0|^8.0|^9.0|^10.0",


### PR DESCRIPTION
Removendo psr/log do composer.json pois conflita com a instalação do Laravel 9/10 que já instala o monolog/monolog e por consequencia o psr/log nas versões corretas.